### PR TITLE
feat: use the built-in https package for testing the URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,9 +11,6 @@
       "@commitlint/config-conventional"
     ]
   },
-  "dependencies": {
-    "ohmyfetch": "^0.4.14"
-  },
   "devDependencies": {
     "@commitlint/cli": "16.0.1",
     "@commitlint/config-conventional": "16.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: 5.3
+lockfileVersion: 5.4
 
 specifiers:
   '@commitlint/cli': 16.0.1
@@ -26,7 +26,6 @@ specifiers:
   eslint-plugin-unicorn: ^40.0.0
   husky: 7.0.4
   nodemon: ^2.0.15
-  ohmyfetch: ^0.4.14
   prettier: 2.5.1
   semantic-release: 18.0.1
   tslib: 2.3.1
@@ -34,9 +33,6 @@ specifiers:
   typescript: 4.5.4
   vite: ^2.7.10
   vitest: ^0.0.125
-
-dependencies:
-  ohmyfetch: 0.4.14
 
 devDependencies:
   '@commitlint/cli': 16.0.1_@types+node@17.0.5
@@ -48,15 +44,15 @@ devDependencies:
   '@semantic-release/npm': 8.0.3_semantic-release@18.0.1
   '@semantic-release/release-notes-generator': 10.0.3_semantic-release@18.0.1
   '@types/node': 17.0.5
-  '@typescript-eslint/eslint-plugin': 5.8.1_13039593e64cd539d0b4c5c2da390958
-  '@typescript-eslint/parser': 5.8.1_eslint@8.6.0+typescript@4.5.4
+  '@typescript-eslint/eslint-plugin': 5.8.1_cmbzle7gjtkttufuyxbnuoijla
+  '@typescript-eslint/parser': 5.8.1_z3gsmzc3xu6w45afpmnsgzwvm4
   commitizen: 4.2.4_@types+node@17.0.5
   cz-conventional-changelog: 3.3.0_@types+node@17.0.5
   esbuild: 0.14.10
   eslint: 8.6.0
   eslint-config-galex: 3.5.4_eslint@8.6.0
   eslint-import-resolver-node: 0.3.6
-  eslint-plugin-import: 2.25.3_eslint@8.6.0
+  eslint-plugin-import: 2.25.3_nzyztdwnxe4ec6vr4lfe4aspbe
   eslint-plugin-inclusive-language: 2.2.0
   eslint-plugin-jest-formatting: 3.1.0_eslint@8.6.0
   eslint-plugin-promise: 6.0.0_eslint@8.6.0
@@ -109,7 +105,7 @@ packages:
       - supports-color
     dev: true
 
-  /@babel/eslint-parser/7.16.5_@babel+core@7.16.5+eslint@8.6.0:
+  /@babel/eslint-parser/7.16.5_eklgnauuxy4cxyewdk3dlhcrya:
     resolution: {integrity: sha512-mUqYa46lgWqHKQ33Q6LNCGp/wPR3eqOYTUixHFsfrSQqRxH0+WOzca75iEjFr5RDGH1dDz622LaHhLOzOuQRUA==}
     engines: {node: ^10.13.0 || ^12.13.0 || >=14.0.0}
     peerDependencies:
@@ -258,6 +254,8 @@ packages:
     resolution: {integrity: sha512-sR4eaSrnM7BV7QPzGfEX5paG/6wrZM3I0HDzfIAK06ESvo9oy3xBuVBxE3MbQaKNhvg8g/ixjMWo2CGpzpHsDA==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+    dependencies:
+      '@babel/types': 7.16.7
     dev: true
 
   /@babel/plugin-syntax-jsx/7.16.7_@babel+core@7.16.5:
@@ -464,7 +462,7 @@ packages:
       '@commitlint/types': 16.0.0
       chalk: 4.1.2
       cosmiconfig: 7.0.1
-      cosmiconfig-typescript-loader: 1.0.2_bad060d5f9aca5284661d88d739ba15b
+      cosmiconfig-typescript-loader: 1.0.2_xligbvpzvsssqrtb3cgxhg5blm
       lodash: 4.17.21
       resolve-from: 5.0.0
       typescript: 4.5.4
@@ -941,6 +939,12 @@ packages:
     resolution: {integrity: sha1-7ihweulOEdK4J7y+UnC86n8+ce4=}
     dev: true
 
+  /@types/keyv/3.1.4:
+    resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
+    dependencies:
+      '@types/node': 17.0.5
+    dev: true
+
   /@types/minimist/1.2.2:
     resolution: {integrity: sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==}
     dev: true
@@ -957,6 +961,12 @@ packages:
     resolution: {integrity: sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==}
     dev: true
 
+  /@types/responselike/1.0.0:
+    resolution: {integrity: sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==}
+    dependencies:
+      '@types/node': 17.0.5
+    dev: true
+
   /@types/retry/0.12.1:
     resolution: {integrity: sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==}
     dev: true
@@ -971,7 +981,7 @@ packages:
       '@types/yargs-parser': 20.2.1
     dev: true
 
-  /@typescript-eslint/eslint-plugin/5.8.1_13039593e64cd539d0b4c5c2da390958:
+  /@typescript-eslint/eslint-plugin/5.8.1_cmbzle7gjtkttufuyxbnuoijla:
     resolution: {integrity: sha512-wTZ5oEKrKj/8/366qTM366zqhIKAp6NCMweoRONtfuC07OAU9nVI2GZZdqQ1qD30WAAtcPdkH+npDwtRFdp4Rw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -982,8 +992,8 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/experimental-utils': 5.8.1_eslint@8.6.0+typescript@4.5.4
-      '@typescript-eslint/parser': 5.8.1_eslint@8.6.0+typescript@4.5.4
+      '@typescript-eslint/experimental-utils': 5.8.1_z3gsmzc3xu6w45afpmnsgzwvm4
+      '@typescript-eslint/parser': 5.8.1_z3gsmzc3xu6w45afpmnsgzwvm4
       '@typescript-eslint/scope-manager': 5.8.1
       debug: 4.3.3
       eslint: 8.6.0
@@ -997,7 +1007,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/experimental-utils/5.8.1_eslint@8.6.0+typescript@4.5.4:
+  /@typescript-eslint/experimental-utils/5.8.1_z3gsmzc3xu6w45afpmnsgzwvm4:
     resolution: {integrity: sha512-fbodVnjIDU4JpeXWRDsG5IfIjYBxEvs8EBO8W1+YVdtrc2B9ppfof5sZhVEDOtgTfFHnYQJDI8+qdqLYO4ceww==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1015,7 +1025,7 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/parser/5.8.1_eslint@8.6.0+typescript@4.5.4:
+  /@typescript-eslint/parser/5.8.1_z3gsmzc3xu6w45afpmnsgzwvm4:
     resolution: {integrity: sha512-K1giKHAjHuyB421SoXMXFHHVI4NdNY603uKw92++D3qyxSeYvC10CBJ/GE5Thpo4WTUvu1mmJI2/FFkz38F2Gw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1699,7 +1709,7 @@ packages:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
     dev: true
 
-  /cosmiconfig-typescript-loader/1.0.2_bad060d5f9aca5284661d88d739ba15b:
+  /cosmiconfig-typescript-loader/1.0.2_xligbvpzvsssqrtb3cgxhg5blm:
     resolution: {integrity: sha512-27ZehvijYqAKVzta5xtZBS3PAliC8CmnWkGXN0vgxAZz7yqxpMjf3aG7flxF5rEiu8FAD7nZZXtOI+xUGn+bVg==}
     engines: {node: '>=12', npm: '>=6'}
     peerDependencies:
@@ -1708,7 +1718,7 @@ packages:
     dependencies:
       '@types/node': 17.0.5
       cosmiconfig: 7.0.1
-      ts-node: 10.4.0_bad060d5f9aca5284661d88d739ba15b
+      ts-node: 10.4.0_xligbvpzvsssqrtb3cgxhg5blm
       typescript: 4.5.4
     transitivePeerDependencies:
       - '@swc/core'
@@ -1789,25 +1799,42 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /data-uri-to-buffer/4.0.0:
-    resolution: {integrity: sha512-Vr3mLBA8qWmcuschSLAOogKgQ/Jwxulv3RNE4FXnYWRGujzrRWQI4m12fQqRkwX06C0KanhLr4hK+GydchZsaA==}
-    engines: {node: '>= 12'}
-    dev: false
-
   /dateformat/3.0.3:
     resolution: {integrity: sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==}
     dev: true
 
   /debug/2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
     dependencies:
       ms: 2.0.0
     dev: true
 
   /debug/3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
     dependencies:
       ms: 2.1.3
+    dev: true
+
+  /debug/3.2.7_supports-color@5.5.0:
+    resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.3
+      supports-color: 5.5.0
     dev: true
 
   /debug/4.3.3:
@@ -1890,10 +1917,6 @@ packages:
   /deprecation/2.3.1:
     resolution: {integrity: sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==}
     dev: true
-
-  /destr/1.1.0:
-    resolution: {integrity: sha512-Ev/sqS5AzzDwlpor/5wFCDu0dYMQu/0x2D6XfAsQ0E7uQmamIgYJ6Dppo2T2EOFVkeVYWjc+PCLKaqZZ57qmLg==}
-    dev: false
 
   /detect-file/1.0.0:
     resolution: {integrity: sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=}
@@ -2383,17 +2406,17 @@ packages:
       eslint: '>=8.5.0'
     dependencies:
       '@babel/core': 7.16.5
-      '@babel/eslint-parser': 7.16.5_@babel+core@7.16.5+eslint@8.6.0
+      '@babel/eslint-parser': 7.16.5_eklgnauuxy4cxyewdk3dlhcrya
       '@babel/preset-react': 7.16.5_@babel+core@7.16.5
       '@next/eslint-plugin-next': 12.0.7
-      '@typescript-eslint/eslint-plugin': 5.8.1_13039593e64cd539d0b4c5c2da390958
-      '@typescript-eslint/parser': 5.8.1_eslint@8.6.0+typescript@4.5.4
+      '@typescript-eslint/eslint-plugin': 5.8.1_cmbzle7gjtkttufuyxbnuoijla
+      '@typescript-eslint/parser': 5.8.1_z3gsmzc3xu6w45afpmnsgzwvm4
       confusing-browser-globals: 1.0.11
       eslint: 8.6.0
       eslint-config-prettier: 8.3.0_eslint@8.6.0
       eslint-import-resolver-jsconfig: 1.1.0
-      eslint-plugin-import: 2.25.3_eslint@8.6.0
-      eslint-plugin-jest: 25.3.2_0c623337b72e31c0f65a874e97fd10ad
+      eslint-plugin-import: 2.25.3_nzyztdwnxe4ec6vr4lfe4aspbe
+      eslint-plugin-jest: 25.3.2_brrdgn5xfyy4b5s2q5hjp7iqvu
       eslint-plugin-jest-dom: 4.0.0_eslint@8.6.0
       eslint-plugin-jest-formatting: 3.1.0_eslint@8.6.0
       eslint-plugin-jsx-a11y: 6.5.1_eslint@8.6.0
@@ -2401,12 +2424,14 @@ packages:
       eslint-plugin-react: 7.28.0_eslint@8.6.0
       eslint-plugin-react-hooks: 4.3.0_eslint@8.6.0
       eslint-plugin-sonarjs: 0.11.0_eslint@8.6.0
-      eslint-plugin-storybook: 0.5.5_eslint@8.6.0+typescript@4.5.4
-      eslint-plugin-testing-library: 5.0.1_eslint@8.6.0+typescript@4.5.4
+      eslint-plugin-storybook: 0.5.5_z3gsmzc3xu6w45afpmnsgzwvm4
+      eslint-plugin-testing-library: 5.0.1_z3gsmzc3xu6w45afpmnsgzwvm4
       eslint-plugin-unicorn: 39.0.0_eslint@8.6.0
       read-pkg-up: 7.0.1
       typescript: 4.5.4
     transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
       - jest
       - supports-color
     dev: true
@@ -2433,30 +2458,55 @@ packages:
     dependencies:
       debug: 3.2.7
       resolve: 1.20.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
-  /eslint-module-utils/2.7.1:
+  /eslint-module-utils/2.7.1_h4cpvfscewbcnweysjsk6etz5m:
     resolution: {integrity: sha512-fjoetBXQZq2tSTWZ9yWVl2KuFrTZZH3V+9iD1V1RfpDgxzJR+mPd/KZmMiA8gbPqdBzpNiEHOuT7IYEWxrH0zQ==}
     engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
     dependencies:
+      '@typescript-eslint/parser': 5.8.1_z3gsmzc3xu6w45afpmnsgzwvm4
       debug: 3.2.7
+      eslint-import-resolver-node: 0.3.6
       find-up: 2.1.0
       pkg-dir: 2.0.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
-  /eslint-plugin-import/2.25.3_eslint@8.6.0:
+  /eslint-plugin-import/2.25.3_nzyztdwnxe4ec6vr4lfe4aspbe:
     resolution: {integrity: sha512-RzAVbby+72IB3iOEL8clzPLzL3wpDrlwjsTBAQXgyp5SeTqqY+0bFubwuo+y/HLhNZcXV4XqTBO4LGsfyHIDXg==}
     engines: {node: '>=4'}
     peerDependencies:
+      '@typescript-eslint/parser': '*'
       eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
     dependencies:
+      '@typescript-eslint/parser': 5.8.1_z3gsmzc3xu6w45afpmnsgzwvm4
       array-includes: 3.1.4
       array.prototype.flat: 1.2.5
       debug: 2.6.9
       doctrine: 2.1.0
       eslint: 8.6.0
       eslint-import-resolver-node: 0.3.6
-      eslint-module-utils: 2.7.1
+      eslint-module-utils: 2.7.1_h4cpvfscewbcnweysjsk6etz5m
       has: 1.0.3
       is-core-module: 2.8.0
       is-glob: 4.0.3
@@ -2464,6 +2514,10 @@ packages:
       object.values: 1.1.5
       resolve: 1.20.0
       tsconfig-paths: 3.12.0
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
     dev: true
 
   /eslint-plugin-inclusive-language/2.2.0:
@@ -2493,7 +2547,7 @@ packages:
       eslint: 8.6.0
     dev: true
 
-  /eslint-plugin-jest/25.3.2_0c623337b72e31c0f65a874e97fd10ad:
+  /eslint-plugin-jest/25.3.2_brrdgn5xfyy4b5s2q5hjp7iqvu:
     resolution: {integrity: sha512-1aPC7RRJkMCNgklHMDECw8fnzag3JBH53LaxmFkDTR7+PfMCO5V6f8XFRHoT2I+Fr4pVO9cPdRGlf7/haB2O5Q==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     peerDependencies:
@@ -2506,8 +2560,8 @@ packages:
       jest:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.8.1_13039593e64cd539d0b4c5c2da390958
-      '@typescript-eslint/experimental-utils': 5.8.1_eslint@8.6.0+typescript@4.5.4
+      '@typescript-eslint/eslint-plugin': 5.8.1_cmbzle7gjtkttufuyxbnuoijla
+      '@typescript-eslint/experimental-utils': 5.8.1_z3gsmzc3xu6w45afpmnsgzwvm4
       eslint: 8.6.0
     transitivePeerDependencies:
       - supports-color
@@ -2585,14 +2639,14 @@ packages:
       eslint: 8.6.0
     dev: true
 
-  /eslint-plugin-storybook/0.5.5_eslint@8.6.0+typescript@4.5.4:
+  /eslint-plugin-storybook/0.5.5_z3gsmzc3xu6w45afpmnsgzwvm4:
     resolution: {integrity: sha512-o4BxfmYTi1mCNdSjBKb59XCkRP4zzd/eLImXiF3KU4i8bQxG8aF+WDQ1b+gM5ixejmmsTyw/cBkOZQmPk1Kb2g==}
     engines: {node: 12.x || 14.x || >= 16}
     peerDependencies:
       eslint: '>=6'
     dependencies:
       '@storybook/csf': 0.0.1
-      '@typescript-eslint/experimental-utils': 5.8.1_eslint@8.6.0+typescript@4.5.4
+      '@typescript-eslint/experimental-utils': 5.8.1_z3gsmzc3xu6w45afpmnsgzwvm4
       eslint: 8.6.0
       requireindex: 1.2.0
     transitivePeerDependencies:
@@ -2600,13 +2654,13 @@ packages:
       - typescript
     dev: true
 
-  /eslint-plugin-testing-library/5.0.1_eslint@8.6.0+typescript@4.5.4:
+  /eslint-plugin-testing-library/5.0.1_z3gsmzc3xu6w45afpmnsgzwvm4:
     resolution: {integrity: sha512-8ZV4HbbacvOwu+adNnGpYd8E64NRcil2a11aFAbc/TZDUB/xxK2c8Z+LoeoHUbxNBGbTUdpAE4YUugxK85pcwQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0, npm: '>=6'}
     peerDependencies:
       eslint: ^7.5.0 || ^8.0.0
     dependencies:
-      '@typescript-eslint/experimental-utils': 5.8.1_eslint@8.6.0+typescript@4.5.4
+      '@typescript-eslint/experimental-utils': 5.8.1_z3gsmzc3xu6w45afpmnsgzwvm4
       eslint: 8.6.0
     transitivePeerDependencies:
       - supports-color
@@ -2684,7 +2738,7 @@ packages:
       eslint: '>=7.0.0'
     dependencies:
       '@babel/core': 7.16.5
-      '@babel/eslint-parser': 7.16.5_@babel+core@7.16.5+eslint@8.6.0
+      '@babel/eslint-parser': 7.16.5_eklgnauuxy4cxyewdk3dlhcrya
       eslint: 8.6.0
       eslint-visitor-keys: 2.1.0
       esquery: 1.4.0
@@ -2864,13 +2918,6 @@ packages:
       reusify: 1.0.4
     dev: true
 
-  /fetch-blob/3.1.3:
-    resolution: {integrity: sha512-ax1Y5I9w+9+JiM+wdHkhBoxew+zG4AJ2SvAD1v1szpddUIiPERVGBxrMcB2ZqW0Y3PP8bOWYv2zqQq1Jp2kqUQ==}
-    engines: {node: ^12.20 || >= 14.13}
-    dependencies:
-      web-streams-polyfill: 3.2.0
-    dev: false
-
   /figures/2.0.0:
     resolution: {integrity: sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=}
     engines: {node: '>=4'}
@@ -2961,13 +3008,6 @@ packages:
   /flatted/3.2.4:
     resolution: {integrity: sha512-8/sOawo8tJ4QOBX8YlQBMxL8+RLZfxMQOif9o0KUKTNTjMYElWPE0r/m5VNFxTRd0NSw8qSy8dajrwX4RYI1Hw==}
     dev: true
-
-  /formdata-polyfill/4.0.10:
-    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
-    engines: {node: '>=12.20.0'}
-    dependencies:
-      fetch-blob: 3.1.3
-    dev: false
 
   /from2/2.3.0:
     resolution: {integrity: sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=}
@@ -3222,6 +3262,8 @@ packages:
     dependencies:
       '@sindresorhus/is': 0.14.0
       '@szmarczak/http-timer': 1.1.2
+      '@types/keyv': 3.1.4
+      '@types/responselike': 1.0.0
       cacheable-request: 6.1.0
       decompress-response: 3.3.0
       duplexer3: 0.1.4
@@ -4136,15 +4178,6 @@ packages:
       whatwg-url: 5.0.0
     dev: true
 
-  /node-fetch/3.1.0:
-    resolution: {integrity: sha512-QU0WbIfMUjd5+MUzQOYhenAazakV7Irh1SGkWCsRzBwvm4fAhzEUaHMJ6QLP7gWT6WO9/oH2zhKMMGMuIrDyKw==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    dependencies:
-      data-uri-to-buffer: 4.0.0
-      fetch-blob: 3.1.3
-      formdata-polyfill: 4.0.10
-    dev: false
-
   /node-releases/2.0.1:
     resolution: {integrity: sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA==}
     dev: true
@@ -4156,7 +4189,7 @@ packages:
     requiresBuild: true
     dependencies:
       chokidar: 3.5.2
-      debug: 3.2.7
+      debug: 3.2.7_supports-color@5.5.0
       ignore-by-default: 1.0.1
       minimatch: 3.0.4
       pstree.remy: 1.1.8
@@ -4349,15 +4382,6 @@ packages:
       define-properties: 1.1.3
       es-abstract: 1.19.1
     dev: true
-
-  /ohmyfetch/0.4.14:
-    resolution: {integrity: sha512-kWllHM3DVJdwB4BpEoHhe+JUviDArit3ZQyVI2X2sxhCYZXlGHAABrsjJ07bac0RG3tae08BnKWy4eRMPKMh4w==}
-    dependencies:
-      destr: 1.1.0
-      node-fetch: 3.1.0
-      ufo: 0.7.9
-      undici: 4.12.1
-    dev: false
 
   /once/1.4.0:
     resolution: {integrity: sha1-WDsap3WWHUsROsF9nFC6753Xa9E=}
@@ -5392,7 +5416,7 @@ packages:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
     dev: true
 
-  /ts-node/10.4.0_bad060d5f9aca5284661d88d739ba15b:
+  /ts-node/10.4.0_xligbvpzvsssqrtb3cgxhg5blm:
     resolution: {integrity: sha512-g0FlPvvCXSIO1JDF6S232P5jPYqBkRL9qly81ZgAOSU7rwI0stphCgd2kLiCrU9DjQCrJMWEqcNSjQL02s6d8A==}
     hasBin: true
     peerDependencies:
@@ -5532,10 +5556,6 @@ packages:
     hasBin: true
     dev: true
 
-  /ufo/0.7.9:
-    resolution: {integrity: sha512-6t9LrLk3FhqTS+GW3IqlITtfRB5JAVr5MMNjpBECfK827W+Vh5Ilw/LhTcHWrt6b3hkeBvcbjx4Ti7QVFzmcww==}
-    dev: false
-
   /uglify-js/3.14.5:
     resolution: {integrity: sha512-qZukoSxOG0urUTvjc2ERMTcAy+BiFh3weWAkeurLwjrCba73poHmG3E36XEjd/JGukMzwTL7uCxZiAexj8ppvQ==}
     engines: {node: '>=0.8.0'}
@@ -5556,11 +5576,6 @@ packages:
   /undefsafe/2.0.5:
     resolution: {integrity: sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==}
     dev: true
-
-  /undici/4.12.1:
-    resolution: {integrity: sha512-MSfap7YiQJqTPP12C11PFRs9raZuVicDbwsZHTjB0a8+SsCqt7KdUis54f373yf7ZFhJzAkGJLaKm0202OIxHg==}
-    engines: {node: '>=12.18'}
-    dev: false
 
   /unique-string/2.0.0:
     resolution: {integrity: sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==}
@@ -5690,11 +5705,6 @@ packages:
       - sass
       - stylus
     dev: true
-
-  /web-streams-polyfill/3.2.0:
-    resolution: {integrity: sha512-EqPmREeOzttaLRm5HS7io98goBgZ7IVz79aDvqjD0kYXLtFZTc0T/U6wHTPKyIjb+MdN7DFIIX6hgdBEpWmfPA==}
-    engines: {node: '>= 8'}
-    dev: false
 
   /webidl-conversions/3.0.1:
     resolution: {integrity: sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=}

--- a/src/modules/https-utils.ts
+++ b/src/modules/https-utils.ts
@@ -23,9 +23,13 @@ export function requestWorks(
 ): Promise<boolean> {
   return new Promise<boolean>((resolve) => {
     try {
-      request(url, { method }, (result) => {
+      let req = request(url, { method }, (result) => {
         return resolve(isStatusOK(result));
       });
+      req.on("error", (_error) => {
+        resolve(false);
+      });
+      req.end();
     } catch {
       return resolve(false);
     }

--- a/src/modules/https-utils.ts
+++ b/src/modules/https-utils.ts
@@ -1,0 +1,33 @@
+import { type IncomingMessage } from "http";
+import { request } from "https";
+
+function isStatusOK(result: IncomingMessage) {
+  return (
+    result.statusCode !== undefined &&
+    result.statusCode >= 200 &&
+    result.statusCode <= 399
+  );
+}
+
+/**
+ * Check if a request for the given URL works
+ *
+ * @param url The given URL
+ * @returns A promise that resolves to a boolean indicating if the URL works
+ *
+ * @note the function doesn't throw an exception
+ */
+export function requestWorks(
+  url: string,
+  method: string | undefined
+): Promise<boolean> {
+  return new Promise<boolean>((resolve) => {
+    try {
+      request(url, { method }, (result) => {
+        return resolve(isStatusOK(result));
+      });
+    } catch {
+      return resolve(false);
+    }
+  });
+}

--- a/src/modules/isUrlOnline.ts
+++ b/src/modules/isUrlOnline.ts
@@ -1,4 +1,4 @@
-import { fetch } from "ohmyfetch";
+import { requestWorks } from "./https-utils";
 import { isUrlString } from "./isUrlString";
 /**
  * @param  {string} url
@@ -11,28 +11,18 @@ export const isUrlOnline = async (url: string): Promise<boolean> => {
   if (!isString) {
     return false;
   }
-  let response;
-  try {
-    response = await fetch(url, { method: "HEAD" });
-  } catch {
-    return false;
-  }
-  if (response.ok) {
-    return true;
-  }
-  if (!response) {
-    try {
-      response = await fetch(url, { method: "GET" });
-    } catch {
-      return false;
-    }
-  }
-  if (response.ok) {
+
+  // first check HEAD
+  let response = await requestWorks(url, "HEAD");
+  if (response) {
     return true;
   }
 
-  if (response.status > 400 && response.status < 500) {
-    return false;
+  // then check HEAD
+  response = await requestWorks(url, "GET");
+  if (response) {
+    return true;
   }
-  return true;
+
+  return false;
 };

--- a/src/modules/isUrlOnline.ts
+++ b/src/modules/isUrlOnline.ts
@@ -18,7 +18,7 @@ export const isUrlOnline = async (url: string): Promise<boolean> => {
     return true;
   }
 
-  // then check HEAD
+  // then check GET
   response = await requestWorks(url, "GET");
   if (response) {
     return true;


### PR DESCRIPTION
use the built-in https package for testing the URLs. This reduces the bundle size to less than a Kilobyte (`0.729 KB`)

Fixes #39 

![image](https://user-images.githubusercontent.com/16418197/183537281-1a300010-4bd8-4571-8d0c-7cab07cd4474.png)
